### PR TITLE
Readme: Add a name to the mysql Container in the

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker build -t moodle .
 To spawn a new instance of Moodle:
 
 ```
-docker run -d -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle centurylink/mysql
+docker run -d --name DB -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle centurylink/mysql
 docker run -d -P --name moodle --link DB:DB -e MOODLE_URL=http://192.168.59.103:8080 -p 8080:80 jauer/moodle
 ```
 


### PR DESCRIPTION
I think you have to add a name to the mysql Container. If you don't add the name "DB" you can't link the moodle Container. 
