### PR TITLE
Upgrade, SSL, exit-bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM ubuntu:14.04
 MAINTAINER Jon Auer <jda@coldshore.com>
 
 VOLUME ["/var/moodledata"]
-EXPOSE 80
+EXPOSE 80 443
 COPY moodle-config.php /var/www/html/config.php
+
+# Enable SSL, moodle requires it
+RUN a2enmod ssl && a2ensite default-ssl # if using proxy, don't need actually secure connection
 
 # Keep upstart from complaining
 # RUN dpkg-divert --local --rename --add /sbin/initctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ VOLUME ["/var/moodledata"]
 EXPOSE 80 443
 COPY moodle-config.php /var/www/html/config.php
 
-# Enable SSL, moodle requires it
-RUN a2enmod ssl && a2ensite default-ssl # if using proxy, don't need actually secure connection
-
 # Keep upstart from complaining
 # RUN dpkg-divert --local --rename --add /sbin/initctl
 # RUN ln -sf /bin/true /sbin/initctl
@@ -37,6 +34,9 @@ RUN apt-get update && \
 	rm /var/www/html/index.html && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/foreground.sh
+
+# Enable SSL, moodle requires it
+RUN a2enmod ssl && a2ensite default-ssl # if using proxy, don't need actually secure connection
 
 CMD ["/etc/apache2/foreground.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 		php5-gd libapache2-mod-php5 postfix wget supervisor php5-pgsql curl libcurl3 \
 		libcurl3-dev php5-curl php5-xmlrpc php5-intl php5-mysql git-core && \
 	cd /tmp && \
-	git clone -b MOODLE_27_STABLE git://git.moodle.org/moodle.git && \
+	git clone -b MOODLE_29_STABLE git://git.moodle.org/moodle.git && \
 	mv /tmp/moodle/* /var/www/html/ && \
 	rm /var/www/html/index.html && \
 	chown -R www-data:www-data /var/www/html && \

--- a/foreground.sh
+++ b/foreground.sh
@@ -8,4 +8,5 @@ read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
 trap "kill -TERM -$pgrp; exit" EXIT TERM KILL SIGKILL SIGTERM SIGQUIT
 
 source /etc/apache2/envvars
-apache2 -D FOREGROUND
+tail -F /var/log/apache2/* &
+exec apache2 -D FOREGROUND


### PR DESCRIPTION
Upgraded to MOODLE_29_STABLE, seems to work.

Enabled SSL using default certificate, seems to be required by moddle. Useful, when using an encrypting reverse proxy like https://hub.docker.com/r/jwilder/nginx-proxy/. With this proxy have to set -e VIRTUAL_PROTO=https for the moodle container.

Fixed exit-bug that caused the container to be killed when stopping. Now shuts down correctly.
