### PR TITLE
Update lockmysql5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 		php-gd libapache2-mod-php postfix wget supervisor php-pgsql curl libcurl3 \
 		libcurl3-dev php-curl php-xmlrpc php-intl php-mysql git-core php-xml php-mbstring php-zip php-soap cron php7.0-ldap && \
 	cd /tmp && \
-	git clone -b MOODLE_33_STABLE git://git.moodle.org/moodle.git --depth=1 && \
+	git clone -b MOODLE_34_STABLE git://git.moodle.org/moodle.git --depth=1 && \
 	mv /tmp/moodle/* /var/www/html/ && \
 	rm /var/www/html/index.html && \
 	chown -R www-data:www-data /var/www/html && \

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ The following aren't handled, considered, or need work:
 
 ## Credits
 
-This is a fork of [Jon Auer's](https://github.com/jda/docker-moodle) Dockerfile.
+This is a fork of [Jade Auer's](https://github.com/jda/docker-moodle) Dockerfile.
 This is a reductionist take on [sergiogomez](https://github.com/sergiogomez/)'s docker-moodle Dockerfile.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ docker-moodle
 A Dockerfile that installs and runs the latest Moodle 3.3 stable, with external MySQL Database.
 
 Tags:
-* latest - 3.3 stable
+* latest - 3.4 stable
+* v3.4 - 3.4 stable
 * v3.2 - 3.2 stable
 * v3.1 - 3.1 stable
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ docker-moodle
 
 A Dockerfile that installs and runs the latest Moodle 3.4 stable, with external MySQL Database.
 
+`Note: DB Deployment uses version 5 of MySQL. MySQL:Latest is now v8.`
+
 Tags:
 * latest - 3.4 stable
 * v3.4 - 3.4 stable
@@ -28,7 +30,7 @@ When running locally or for a test deployment, use of localhost is acceptable.
 To spawn a new instance of Moodle:
 
 ```
-docker run -d --name DB -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_ROOT_PASSWORD=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle mysql
+docker run -d --name DB -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_ROOT_PASSWORD=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle mysql:5
 docker run -d -P --name moodle --link DB:DB -e MOODLE_URL=http://localhost:8080 -p 8080:80 jhardison/moodle
 ```
 
@@ -45,7 +47,7 @@ In the following steps, replace MOODLE_URL with your appropriate FQDN.
 
 * Deploy With Docker
 ```
-docker run -d --name DB -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_ROOT_PASSWORD=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle mysql
+docker run -d --name DB -p 3306:3306 -e MYSQL_DATABASE=moodle -e MYSQL_ROOT_PASSWORD=moodle -e MYSQL_USER=moodle -e MYSQL_PASSWORD=moodle mysql:5
 docker run -d -P --name moodle --link DB:DB -e MOODLE_URL=http://moodle.company.com -p 80:80 jhardison/moodle
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Dockerfile that installs and runs the latest Moodle 3.4 stable, with external 
 Tags:
 * latest - 3.4 stable
 * v3.4 - 3.4 stable
+# v3.3 - 3.3 stable
 * v3.2 - 3.2 stable
 * v3.1 - 3.1 stable
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ docker-moodle
 =============
 [![](https://images.microbadger.com/badges/image/jhardison/moodle.svg)](https://microbadger.com/images/jhardison/moodle "Get your own image badge on microbadger.com")
 
-A Dockerfile that installs and runs the latest Moodle 3.3 stable, with external MySQL Database.
+A Dockerfile that installs and runs the latest Moodle 3.4 stable, with external MySQL Database.
 
 Tags:
 * latest - 3.4 stable

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Dockerfile that installs and runs the latest Moodle 3.4 stable, with external 
 Tags:
 * latest - 3.4 stable
 * v3.4 - 3.4 stable
-# v3.3 - 3.3 stable
+* v3.3 - 3.3 stable
 * v3.2 - 3.2 stable
 * v3.1 - 3.1 stable
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     dbapp:
-        image: mysql:latest
+        image: mysql:5
         restart: always
         volumes:
             - db-volume:/var/lib/mysql


### PR DESCRIPTION
MySQL:Latest was updated to use MySQL version 8. Tracking some issues on Moodle for support of MySQL 8. For now, updating compose and documentation to use mysql:5 to resolve DB connectivity issues.